### PR TITLE
Migrate to Jekyll with Chirpy theme

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,0 +1,31 @@
+name: Build and Deploy Jekyll site
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Build site
+        run: bundle exec jekyll build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+          publish_branch: gh-pages

--- a/404.html
+++ b/404.html
@@ -1,0 +1,5 @@
+---
+layout: 404
+title: Page not found
+permalink: /404.html
+---

--- a/_config.yml
+++ b/_config.yml
@@ -1,103 +1,52 @@
 # Site settings
 title: Ollama Labs
 tagline: Run Large Language Models Locally
-description: >-
+description: >
   Your comprehensive resource for Ollama - the tool that makes it easy to run large language models locally.
-baseurl: "" # Empty for user site, use "/ollama-labs" for project site if needed
-url: "https://ollama.collabnix.com" # Use your custom domain
-logo: "/assets/images/ollama-labs-logo.png"
-favicon_ico: "/assets/images/favicon.ico"
+url: "https://ollama.collabnix.com"
+baseurl: ""
+lang: en
+timezone: UTC
 
-# Social media
-twitter:
-  username: collabnix
-github_username: ajeetraina
-repository: ajeetraina/ollama-labs
+# Author settings
+author:
+  name: Collabnix Community
+  twitter: collabnix
+  github: ajeetraina
 
-# Build settings
-markdown: kramdown
-highlighter: rouge
-permalink: /:categories/:title/
+# GitHub settings
+github:
+  username: ajeetraina
+  repo: ollama-labs
 
 # Theme settings
-theme: jekyll-theme-chirpy # Using Chirpy theme for modern documentation
+theme: jekyll-theme-chirpy
 remote_theme: cotes2020/jekyll-theme-chirpy
+theme_mode: light
 
+# Jekyll plugins
 plugins:
+  - jekyll-paginate
+  - jekyll-sitemap
   - jekyll-feed
   - jekyll-seo-tag
-  - jekyll-sitemap
-  - jekyll-paginate
+  - jekyll-archives
   - jekyll-redirect-from
 
-# Chirpy theme settings
+# Pagination
 paginate: 10
 paginate_path: /blog/page:num/
 
-# Dark/Light mode
-theme_mode: light
+# URLs
+permalink: /:categories/:title/
 
-# Comments system (optional - remove if not needed)
-comments:
-  active: false
-
-# Analytics (optional - add your Google Analytics ID)
-# google_analytics: UA-XXXXXXXXX-X
+# Collections
+collections:
+  tabs:
+    output: true
+    sort_by: order
 
 # TOC settings
 toc:
-  enabled: true
   min_level: 1
   max_level: 3
-
-# Collections for different content types
-collections:
-  docs:
-    output: true
-    sort_by: order
-  tutorials:
-    output: true
-    sort_by: order
-  labs:
-    output: true
-    sort_by: order
-
-# Default front matter
-defaults:
-  - scope:
-      path: ""
-    values:
-      layout: page
-      comments: false
-  - scope:
-      path: "_posts"
-    values:
-      layout: post
-      comments: false
-  - scope:
-      path: "_docs"
-    values:
-      layout: doc
-  - scope:
-      path: "_tutorials"
-    values:
-      layout: tutorial
-  - scope:
-      path: "_labs"
-    values:
-      layout: lab
-
-# Exclude from processing
-exclude:
-  - Gemfile
-  - Gemfile.lock
-  - node_modules
-  - vendor
-  - .idea/
-  - .gitignore
-  - .github/
-  - README.md
-  - DEPLOYMENT.md
-  - LICENSE
-  - config.toml
-  - config.yaml

--- a/_posts/2025-04-08-welcome-to-ollama-labs.md
+++ b/_posts/2025-04-08-welcome-to-ollama-labs.md
@@ -1,0 +1,31 @@
+---
+layout: post
+title: "Welcome to Ollama Labs"
+date: 2025-04-08 10:00:00 -0000
+categories: [news, announcement]
+tags: [welcome, ollama, introduction]
+---
+
+# Welcome to Ollama Labs
+
+We're excited to launch Ollama Labs, your comprehensive resource for everything related to running Large Language Models (LLMs) locally using Ollama.
+
+## What is Ollama?
+
+Ollama is an open-source tool that makes it easy to run large language models locally on your own hardware. Whether you have a high-end GPU or just a modern CPU, Ollama allows you to run powerful AI models on your own machine without needing to send your data to external APIs.
+
+## What You'll Find Here
+
+At Ollama Labs, we're committed to providing high-quality resources to help you make the most of Ollama:
+
+- **Documentation**: Clear and comprehensive guides to help you install, configure, and use Ollama
+- **Tutorials**: Step-by-step instructions for common tasks and use cases
+- **Labs**: Hands-on exercises to build practical applications
+- **Model Library**: Information about supported models and their performance characteristics
+- **Community Resources**: Links to community projects, extensions, and integrations
+
+## Get Started Today
+
+Head over to our [Documentation](/tabs/docs/) section to learn how to install Ollama and run your first model. Or check out our [Labs](/tabs/labs/) for hands-on exercises.
+
+We're excited to have you join us on this journey of making AI more accessible and private through local model execution!

--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -1,0 +1,24 @@
+---
+layout: page
+title: About
+icon: fas fa-info-circle
+order: 4
+---
+
+# About Ollama Labs
+
+Ollama Labs is a community-driven initiative to provide high-quality tutorials, hands-on labs, and up-to-date information about Ollama - the tool that makes it easy to run large language models locally.
+
+## Our Mission
+
+Our mission is to make AI accessible to everyone by providing clear, concise, and practical resources for running large language models locally.
+
+## Community
+
+Ollama Labs is part of the [Collabnix Community](https://collabnix.com), a vibrant community of developers and enthusiasts interested in containers, cloud, and now AI technologies.
+
+## Contributing
+
+We welcome contributions from the community! Whether it's fixing a typo, adding a new tutorial, or creating a lab exercise, your contributions help make Ollama more accessible to everyone.
+
+Check out our [GitHub repository](https://github.com/ajeetraina/ollama-labs) to get started.

--- a/_tabs/docs.md
+++ b/_tabs/docs.md
@@ -1,0 +1,22 @@
+---
+layout: page
+title: Documentation
+icon: fas fa-book
+order: 2
+---
+
+# Ollama Documentation
+
+Welcome to the Ollama documentation. Here you'll find everything you need to get started with running large language models locally.
+
+## Getting Started
+
+- [Installation Guide](/docs/installation/)
+- [Running Your First Model](/docs/first-model/)
+- [Basic Commands](/docs/basic-commands/)
+
+## Advanced Topics
+
+- [Custom Model Configuration](/docs/custom-models/)
+- [API Integration](/docs/api/)
+- [Performance Optimization](/docs/performance/)

--- a/_tabs/home.md
+++ b/_tabs/home.md
@@ -1,0 +1,6 @@
+---
+layout: home
+title: Home
+icon: fas fa-home
+order: 1
+---

--- a/_tabs/labs.md
+++ b/_tabs/labs.md
@@ -1,0 +1,25 @@
+---
+layout: page
+title: Labs
+icon: fas fa-flask
+order: 3
+---
+
+# Ollama Labs
+
+Our labs are hands-on exercises to help you build practical applications with Ollama.
+
+## Beginner Labs
+
+- [Lab 1: Running Your First Model](/labs/lab1-first-model/)
+- [Lab 2: Building a Simple Chatbot](/labs/lab2-chatbot/)
+
+## Intermediate Labs
+
+- [Lab 3: Python Integration](/labs/lab3-python/)
+- [Lab 4: Custom Chat Interface](/labs/lab4-chat-interface/)
+
+## Advanced Labs
+
+- [Lab 5: Fine-tuning Models](/labs/lab5-fine-tuning/)
+- [Lab 6: Multi-modal Applications](/labs/lab6-multimodal/)

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,152 @@
+---
+---
+
+/*
+  Add your custom styles here
+*/
+
+// Import theme styles
+@import "{{ site.theme }}";
+
+// Home page welcome banner
+.welcome-banner {
+  text-align: center;
+  padding: 4rem 1rem;
+  background: linear-gradient(135deg, #2c3e50, #4ca1af);
+  color: white;
+  border-radius: 0.5rem;
+  margin-bottom: 2rem;
+  
+  h1 {
+    font-size: 2.5rem;
+    margin-bottom: 1rem;
+    color: white;
+  }
+  
+  p {
+    font-size: 1.2rem;
+    margin-bottom: 2rem;
+    opacity: 0.9;
+  }
+  
+  .action-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    
+    .btn {
+      padding: 0.5rem 1.5rem;
+      border-radius: 2rem;
+      font-weight: 600;
+      transition: all 0.3s ease;
+      
+      &:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 5px 15px rgba(0,0,0,0.1);
+      }
+    }
+  }
+}
+
+// Features section
+.features {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+  margin: 3rem 0;
+  
+  .feature {
+    text-align: center;
+    padding: 1.5rem;
+    background-color: #f8f9fa;
+    border-radius: 0.5rem;
+    transition: all 0.3s ease;
+    
+    &:hover {
+      transform: translateY(-5px);
+      box-shadow: 0 10px 20px rgba(0,0,0,0.05);
+    }
+    
+    i {
+      color: #3498db;
+      margin-bottom: 1rem;
+    }
+    
+    h3 {
+      margin-bottom: 1rem;
+      font-size: 1.3rem;
+    }
+    
+    p {
+      color: #666;
+      font-size: 0.95rem;
+    }
+  }
+}
+
+// Post cards
+.posts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+  
+  .post-card {
+    background-color: #fff;
+    border-radius: 0.5rem;
+    padding: 1.5rem;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.05);
+    transition: all 0.3s ease;
+    
+    &:hover {
+      transform: translateY(-3px);
+      box-shadow: 0 8px 25px rgba(0,0,0,0.1);
+    }
+    
+    h3 {
+      margin-bottom: 0.5rem;
+      
+      a {
+        color: #222;
+        text-decoration: none;
+        
+        &:hover {
+          color: #3498db;
+        }
+      }
+    }
+    
+    .post-meta {
+      color: #666;
+      font-size: 0.85rem;
+      margin-bottom: 0.75rem;
+    }
+  }
+}
+
+// Code blocks
+pre.highlight {
+  border-radius: 0.5rem;
+  margin: 1.5rem 0;
+}
+
+// Responsive adjustments
+@media (max-width: 768px) {
+  .welcome-banner {
+    padding: 3rem 1rem;
+    
+    h1 {
+      font-size: 2rem;
+    }
+  }
+  
+  .action-buttons {
+    flex-direction: column;
+    align-items: center;
+    
+    .btn {
+      width: 100%;
+      margin-bottom: 0.5rem;
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,47 @@
+---
+layout: home
+# Index page
+---
+
+<!-- Welcome Banner -->
+<div class="welcome-banner">
+  <h1>Welcome to Ollama Labs</h1>
+  <p>Your comprehensive resource for running Large Language Models locally</p>
+  <div class="action-buttons">
+    <a href="/tabs/docs/" class="btn btn-primary">Get Started</a>
+    <a href="https://github.com/ollama/ollama" class="btn btn-outline-primary">GitHub</a>
+  </div>
+</div>
+
+<!-- Features -->
+<div class="features">
+  <div class="feature">
+    <i class="fas fa-book fa-3x"></i>
+    <h3>Documentation</h3>
+    <p>Comprehensive guides on installation, configuration, and usage</p>
+  </div>
+  <div class="feature">
+    <i class="fas fa-flask fa-3x"></i>
+    <h3>Labs</h3>
+    <p>Hands-on exercises to build practical applications</p>
+  </div>
+  <div class="feature">
+    <i class="fas fa-code fa-3x"></i>
+    <h3>API Reference</h3>
+    <p>Details on integrating Ollama with your applications</p>
+  </div>
+</div>
+
+<!-- Latest Posts -->
+{% if site.posts.size > 0 %}
+<h2>Latest Updates</h2>
+<div class="posts">
+  {% for post in site.posts limit:3 %}
+  <div class="post-card">
+    <h3><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
+    <p class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</p>
+    <p>{{ post.excerpt | strip_html | truncate: 100 }}</p>
+  </div>
+  {% endfor %}
+</div>
+{% endif %}


### PR DESCRIPTION
This PR migrates the Ollama Labs site from the current setup to a modern Jekyll implementation using the Chirpy theme. The changes include:

1. Updated Jekyll configuration with Chirpy theme
2. Modern, responsive design with better navigation
3. Improved documentation structure
4. Sample blog post functionality
5. Custom styling for a more attractive frontend
6. GitHub Actions workflow for automated deployment

After merging, you'll need to:
1. Go to repository Settings > Pages
2. Set the source to "GitHub Actions"
3. Wait for the GitHub Action to build and deploy the site

The new design provides a more professional and user-friendly experience, making your Ollama Labs content more accessible and visually appealing.